### PR TITLE
fix: backport security fixes from app-version branch

### DIFF
--- a/src/utils/FireblocksSigner.ts
+++ b/src/utils/FireblocksSigner.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import {
   Fireblocks,
   TransactionOperation,
@@ -11,12 +12,17 @@ import {
 import { derivationPath } from "./constants";
 import { formatErrorMessage } from "./errorHandling";
 
+const POLL_INITIAL_MS = 3_000;
+const POLL_CEILING_MS = 30_000;
+const POLL_TIMEOUT_MS = 30 * 60 * 1_000;
+
 export class FireblocksSigner {
   constructor(public fireblocks: Fireblocks) {}
 
-  createTransactionPayload = (): TransactionRequest => {
+  createTransactionPayload = (externalTxId: string): TransactionRequest => {
     return {
       note: "raw signing for stacks-fireblocks-sdk",
+      externalTxId,
       source: {
         type: TransferPeerPathType.VaultAccount,
       },
@@ -34,28 +40,34 @@ export class FireblocksSigner {
     let response: FireblocksResponse<TransactionResponse> =
       await this.fireblocks.transactions.getTransaction({ txId });
     let tx: TransactionResponse = response.data;
-    const messageToConsole: string = `Transaction ${tx.id} is currently at status - ${tx.status}`;
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    let delay = POLL_INITIAL_MS;
 
-      console.log(messageToConsole);
-      while (tx.status !== TransactionStateEnum.Completed) {
-        await new Promise((resolve) => setTimeout(resolve, 3000));
+    while (tx.status !== TransactionStateEnum.Completed) {
+      switch (tx.status) {
+        case TransactionStateEnum.Blocked:
+        case TransactionStateEnum.Cancelled:
+        case TransactionStateEnum.Failed:
+        case TransactionStateEnum.Rejected:
+          throw new Error(
+            `Signing request failed/blocked/cancelled: Transaction: ${tx.id} status is ${tx.status}`,
+          );
+      }
 
-        response = await this.fireblocks.transactions.getTransaction({ txId });
-        tx = response.data;
+      if (Date.now() + delay > deadline) {
+        throw new Error(
+          `Signing request timed out after 30 minutes: Transaction ${tx.id} is still ${tx.status}`,
+        );
+      }
 
-        switch (tx.status) {
-          case TransactionStateEnum.Blocked:
-          case TransactionStateEnum.Cancelled:
-          case TransactionStateEnum.Failed:
-          case TransactionStateEnum.Rejected:
-            throw new Error(
-              `Signing request failed/blocked/cancelled: Transaction: ${tx.id} status is ${tx.status}`,
-            );
-          default:
-            console.log(messageToConsole);
-            break;
-        }
+      console.log(`Transaction ${tx.id} is currently at status - ${tx.status}`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      delay = Math.min(delay * 2, POLL_CEILING_MS);
+
+      response = await this.fireblocks.transactions.getTransaction({ txId });
+      tx = response.data;
     }
+
     return tx;
   };
 
@@ -64,6 +76,7 @@ export class FireblocksSigner {
     vaultAccountId: string,
     txNote?: string,
     testnet: boolean = false,
+    externalId?: string,
   ): Promise<any> => {
     try {
       if (typeof content !== "string") {
@@ -72,7 +85,7 @@ export class FireblocksSigner {
 
       const hexContent = content.startsWith("0x") ? content.slice(2) : content;
 
-      const transactionPayload = this.createTransactionPayload();
+      const transactionPayload = this.createTransactionPayload(externalId ?? randomUUID());
 
       if (txNote) {
         transactionPayload.note = txNote;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -12,6 +12,7 @@ import { encodeStructuredDataBytes } from "@stacks/transactions";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@stacks/common";
 import { StacksService } from "../services/stacks.service";
+import { Signature as Secp256k1Signature } from "@noble/secp256k1";
 
 
 // Returns the token info from ftInfo for a given token type and network, or undefined if not found.
@@ -40,18 +41,19 @@ export function validateAmount(amount: string | number): boolean {
 /** Validate a Stacks account address with a network flag. */
 export function validateAddress(addr: string, testnet: boolean): boolean {
   if (testnet) {
-    if (!/^ST[A-Z0-9]+$/.test(addr)) return false;
+    if (!/^S[TN][A-Z0-9]+$/.test(addr)) return false;
   } else {
-    if (!/^SP[A-Z0-9]+$/.test(addr)) return false;
+    if (!/^S[PM][A-Z0-9]+$/.test(addr)) return false;
   }
 
   try {
     const [version, data] = c32addressDecode(addr) as [number, string];
 
-    // Expected version by network (single-sig accounts)
-    // ST → 26 (testnet), SP → 22 (mainnet)
-    const expectedVersion = testnet ? 26 : 22;
-    if (version !== expectedVersion) return false;
+    // Expected versions by network:
+    // Testnet: ST → 26, SN → 21
+    // Mainnet: SP → 22, SM → 20
+    const validVersions = testnet ? [26, 21] : [22, 20];
+    if (!validVersions.includes(version)) return false;
 
     // Payload must be 20 bytes (HASH160)
     return /^[0-9a-fA-F]{40}$/.test(data);
@@ -134,8 +136,23 @@ export function microToToken(
 
 // Concatenate a full signature (r + s) with recovery id v to form a single hex string.
 export function concatSignature(fullSig: string, v: number): string {
-  const vHex = v == 0 ? "00" : "01";
-  return vHex + fullSig;
+  if (v !== 0 && v !== 1) {
+    throw new Error(`Invalid recovery id: expected 0 or 1, got ${v}`);
+  }
+  if (!/^[0-9a-fA-F]{128}$/.test(fullSig)) {
+    throw new Error(`Invalid signature: expected 128 hex chars, got ${fullSig.length}`);
+  }
+
+  const parsed = Secp256k1Signature.fromCompact(fullSig);
+  let normalizedSig = fullSig;
+  let normalizedV = v;
+  if (parsed.hasHighS()) {
+    normalizedSig = parsed.normalizeS().toCompactHex();
+    normalizedV = v ^ 1;
+  }
+
+  const vHex = normalizedV === 0 ? "00" : "01";
+  return vHex + normalizedSig;
 }
 
 // Get decimals for a fungible token from its contract ID
@@ -200,7 +217,7 @@ export function untilBurnHeightForCycles(
   const R = Number(pox.reward_phase_block_length);
   const cycleLen = Q + R;
 
-  return P + cycles * cycleLen - 1;
+  return P + cycles * cycleLen;
 }
 
 // Assert that a transaction result indicates success, else log and return error details.


### PR DESCRIPTION
## Summary

Backports critical security fixes from the `app-version` branch to `main` to ensure both branches have consistent security hardening.

### Security Improvements

**FireblocksSigner.ts:**
- Add `externalTxId` parameter for idempotent signing requests (prevents duplicate transactions on retry)
- Replace fixed 3-second polling with exponential backoff (3s → 30s ceiling)
- Add 30-minute hard timeout to prevent infinite polling during cold storage approvals
- Fix stale log message that never updated during polling loop

**helpers.ts:**
- `concatSignature`: Validate recovery ID v ∈ {0, 1} (reject malformed signatures)
- `concatSignature`: Validate signature is exactly 128 hex characters
- `concatSignature`: Normalize high-S signatures via `@noble/secp256k1` for node compatibility
- `validateAddress`: Support multisig addresses (SM prefix for mainnet, SN for testnet)
- `untilBurnHeightForCycles`: Fix off-by-one error in PoX cycle calculation

## Test Plan

- [ ] Verify signing with externalTxId works correctly
- [ ] Verify exponential backoff behavior in polling
- [ ] Verify timeout triggers after 30 minutes
- [ ] Verify multisig addresses (SM/SN) are accepted
- [ ] Verify high-S signatures are normalized
- [ ] Verify invalid v values are rejected
- [ ] Verify cycle calculation returns correct burn height

## Related

These fixes address issues identified in the June 2026 security review. See `CODE_REVIEW_COMPREHENSIVE_JUNE_2026.md` in the app repo for full details.